### PR TITLE
Make defaultCfg a function instead of an object to fix issue #7.

### DIFF
--- a/src/lib/mock-data-gen.spec.ts
+++ b/src/lib/mock-data-gen.spec.ts
@@ -31,6 +31,20 @@ describe(gen.name, () => {
       }
     });
 
+    it('creates independent generators', () => {
+      const generator1 = gen(t.string);
+      const firstValue1 = generator1.next().value;
+
+      for (let i = 0; i < 10; i++) {
+        generator1.next();
+      }
+
+      const generator2 = gen(t.string);
+      const firstValue2 = generator2.next().value;
+
+      expect(firstValue1).to.equal(firstValue2);
+    });
+
     it(`generates a different output for ${typ.name} with different seeds`, () => {
       const v1 = genOne(typ, { seed: 1 });
       const v2 = genOne(typ, { seed: 2 });

--- a/src/lib/mock-data-gen.ts
+++ b/src/lib/mock-data-gen.ts
@@ -8,18 +8,22 @@ import { RandomSeed } from 'random-seed';
 import { arb, GenerateArbCtx } from './mock-data-gen-arb';
 import { randomUUID } from './random-helpers';
 
-const genDate = (r: RandomSeed) => new Date(r.intBetween(
-                          new Date(1970, 1, 1).valueOf(),
-                          new Date(2100, 1, 1).valueOf()));
+const genDate = (r: RandomSeed) =>
+  new Date(
+    r.intBetween(new Date(1970, 1, 1).valueOf(), new Date(2100, 1, 1).valueOf())
+  );
 
-const defaultCfg: Required<GenCfg> = {
-  namedTypeGens: {
-    Int: (r) => r.intBetween(Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER),
-    Date: genDate,
-    UUID: (r) => randomUUID(r.random()),
-    DateFromISOString: genDate
-  },
-  seed: 0,
+const getDefaultCfg = (): Required<GenCfg> => {
+  return {
+    namedTypeGens: {
+      Int: (r) =>
+        r.intBetween(Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER),
+      Date: genDate,
+      UUID: (r) => randomUUID(r.random()),
+      DateFromISOString: genDate,
+    },
+    seed: 0,
+  };
 };
 
 function doGenValue<R, T extends t.Type<R>>(
@@ -40,7 +44,7 @@ export function* gen<T extends t.Type<any>>(
   typ: T,
   cfg?: GenCfg
 ): Generator<t.TypeOf<T>> {
-  const mergedCfg: Required<GenCfg> = _.merge(defaultCfg, cfg);
+  const mergedCfg: Required<GenCfg> = _.merge(getDefaultCfg(), cfg);
 
   const namedArbs: Record<string, Arbitrary<unknown>> = {};
   for (const [name, typeGen] of Object.entries(mergedCfg.namedTypeGens)) {

--- a/src/lib/regression-tests.spec.ts
+++ b/src/lib/regression-tests.spec.ts
@@ -11,11 +11,11 @@ describe('regression tests', () => {
     const generator = gen(TTest);
     const vals: number[] = [];
     for (let i=0; i<100; ++i) {
-       const val = generator.next().value!;
-       console.log(val);
-       if (!vals.includes(val)) {
-         vals.push(val);
-       }
+      const val = generator.next().value!;
+      console.log(val);
+      if (!vals.includes(val)) {
+        vals.push(val);
+      }
     }
     expect(vals.length > 1).to.be.true;
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,9 @@
     "listFiles": false /* Print names of files part of the compilation. */,
     "pretty": true /* Stylize errors and messages using color and context. */,
 
+    /* Typescript 4.0 now has 'unknown' catch instead of 'any' */
+    "useUnknownInCatchVariables": false /* Use 'any' instead of 'unknown' in catch variable */,
+
     "lib": [
       "es2017",
       "dom",


### PR DESCRIPTION
Fixes the issue caused by ``lodash.merge`` overwriting the original ``defaultCfg`` by returning a newly created config object for each new generator.